### PR TITLE
feat: object-expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,27 @@ Implementation of `expect(...).to` test assertion pattern for dotnet. Implemente
 ### Naming and conventions
 
 This package is not authored by the FluentAssertions team, but is structured according to FluentAssertions project conventions so that it could be easily adopted by that project if they so desired at some point in the future. Likewise, the published package name is `Sabl.Expect` to avoid any ambiguity in authorship and support, but the root namespace is `FluentAssertions.Expectations` for best compatibility in source code.
+
+## Summary
+ 
+Replaces `expression.Should()` extension syntax with `Expect(expression).To()` function call syntax
+ - which avoids all the `Should()` extensions methods
+ - while preserving the entire fluent syntax and API for assertions themselves
+
+### Background
+
+[FluentAssertions](https://github.com/fluentassertions/fluentassertions) provides a mature assertions library for testing .NET projects. 
+
+FluentAssertions' root `value.Should()...` pattern requires [defining extension methods](https://github.com/fluentassertions/fluentassertions/blob/develop/Src/FluentAssertions/AssertionExtensions.cs) on numerous types, including `System.Object` itself. 
+
+Many developers find this pattern intrusive. When they are writing tests, they do not want to see test framework extension methods present in the member listing on every possible expression.
+
+And yet, the vast majority of FluentAssertions' actual API does not depend on the root `Should(...)` extension methods. Rather, the substance of the the actual fluent assertions are defined on the types which are _returned_ from the overloads of `Should()`, such as [`ObjectAssertions`](https://github.com/fluentassertions/fluentassertions/blob/develop/Src/FluentAssertions/Primitives/ObjectAssertions.cs) or [`NullableBooleanAssertions`](https://github.com/fluentassertions/fluentassertions/blob/develop/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs).
+
+This library provides a simple alternative: replacing the `Should()` extension methods with a global `Expect` function, chained with a method `To()`. `Expect` is not an extension method. Calling `Expect(...).To()` is therefore an explicit opt-in to switch from a general acting context to an asserting context. Visually, it also causes the vast majority of assertion lines to begin with the word `Expect`.
+
+To actual return value of `Expect(value).To()` is identical to the return value of `value.Should()` on the same value.
+
+### Opinions
+
+Calling FluentAssertions' extension based syntax "intrusive" is an opinion, a matter of taste. This library does not seek to sway anyone's opinion, nor to criticize the design of FluentAssertions. It simply provides an easy drop-in alternative for code authors who appreciate FluentAssertions but dislike the extension syntax in their own totally subjective opinion. If you or your team prefers the extension syntax, just ignore this library! All actual assertions APIs remain in FluentAssertions itself, even when using this library.

--- a/src/Sabl.Expect/ObjectExpectations.cs
+++ b/src/Sabl.Expect/ObjectExpectations.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Expectations;
+
+public static partial class Expectation
+{
+    public static ObjectExpectation Expect(object? actual)
+        => new(actual);
+}
+
+[DebuggerNonUserCode]
+public class ObjectExpectation(object? actual) : Expectation<object?>(actual) { }
+
+[DebuggerNonUserCode]
+public static class ObjectExpectationExtensions
+{
+    public static ObjectAssertions To(this ObjectExpectation expectation)
+       => expectation.Subject.Should();
+}

--- a/tests/Sabl.Expect.Specs/ObjectExpectationSpecs.cs
+++ b/tests/Sabl.Expect.Specs/ObjectExpectationSpecs.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Expectations.Specs;
+
+public class ObjectExpectationSpecs
+{
+    [Fact]
+    public void Expect_Returns_ObjectAssertions()
+    {
+        object objValue = 232;
+
+        // Act: We are testing Expect(...).To() itself
+        var assertions = Expect(objValue).To();
+
+        // Assert
+        Expect(assertions).To().BeOfType<ObjectAssertions>();
+        assertions.Be(232);
+    }
+}


### PR DESCRIPTION
Adds ObjectExpectation and applicable extensions to support basic Expect(..).To() on object values.