### PR TITLE
As(out var ..) extension for chained expectations

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 

--- a/src/FluentAssertions.Expectations/AndWhichExtensions.cs
+++ b/src/FluentAssertions.Expectations/AndWhichExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace FluentAssertions.Expectations;
+
+/// <summary>
+/// Extension methods to terminate a chain and extract the subject for further assertions
+/// </summary>
+public static class AndWhichExtensions
+{
+    /// <summary>
+    /// Extract the single result of a prior assertion that is used to select a nested or collection item.
+    /// <br/>Synonym for <c>Subject(out TMatchedElement)</c>, <c>Which(out TMatchedElement)</c>
+    /// </summary>
+    public static void As<TParentConstraint, TMatchedElement>(
+        this AndWhichConstraint<TParentConstraint, TMatchedElement> constraint, out TMatchedElement subject)
+    {
+        subject = constraint.Subject;
+    }
+}

--- a/tests/FluentAssertions.Expectations.Specs/AndWhichExtensionsSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/AndWhichExtensionsSpecs.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+
+namespace FluentAssertions.Expectations.Specs;
+
+public class AndWhichExtensionsSpecs
+{
+    [Fact]
+    public void As_Extracts_SubjectPropValue()
+    {
+        List<int> list = [1, 2, 3];
+        IEnumerable maybeList = list;
+
+        // Act: 
+        Expect(maybeList).To().BeAssignableTo<IEnumerable<int>>().As(out var enumerable);
+
+        // Assert: Returned correct subject
+        Expect(enumerable).To().BeSameAs(list);
+
+        // Verify API equivalence
+        var subjectValue = maybeList.Should().BeAssignableTo<IEnumerable<int>>().Subject;
+        Expect(enumerable).To().BeSameAs(subjectValue);
+    }
+}

--- a/tests/inventory.cs
+++ b/tests/inventory.cs
@@ -13,7 +13,7 @@
 public static MemberExecutionTime<T>        ExecutionTimeOf<T>(this T subject, Expression<Action<T>> action, StartTimer createTimer = null) => throw null!;
 public static ExecutionTime                 ExecutionTime(this Action action, StartTimer createTimer = null) => throw null!;
 public static ExecutionTime                 ExecutionTime(this Func<Task> action) => throw null!;
-public static ExecutionTimeAssertions           Should(this ExecutionTime executionTime) => throw null!;
+public static ExecutionTimeAssertions         -> Should(this ExecutionTime executionTime) => throw null!;
 public static IMonitor<T>                   Monitor<T>(this T eventSource, Func<DateTime> utcNow = null) => throw null!;
 
 public static Action                        Enumerating(this Func<IEnumerable> enumerable) => throw null!;


### PR DESCRIPTION
Adds extension method As(...) on AndWhichExpectation to provide an alternative for the Which / Subject-based chained assertion pattern.

### Which / Should replacement

Replace `..BeXXX(..).Which.Should()` with `..BeXXX(..).As(out var v); Expect(v).To()...`