### PR TITLE
feat(comparable): comparabletype expectations

### DIFF
--- a/src/FluentAssertions.Expectations/IComparableExpectations.cs
+++ b/src/FluentAssertions.Expectations/IComparableExpectations.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Expectations;
+
+public static partial class Expectation
+{
+    /// <summary>Create an expectation about a <see cref="IComparable{T}"/> subject</summary>
+    public static Expectation<IComparable<T>> Expect<T>(IComparable<T> actual) => new(actual);
+}
+
+/// <summary>Extensions to <see cref="Expectation{T}"/> about numeric types</summary>
+[DebuggerNonUserCode]
+public static class ComparableExpectationExtensions
+{
+    /// <summary>Compose assertions about the <see cref="int"/> subject</summary>
+    public static ComparableTypeAssertions<T> To<T>(this Expectation<IComparable<T>> expectation)
+        => expectation.Subject.Should();
+
+}

--- a/tests/FluentAssertions.Expectations.Specs/ComparableExpectationSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/ComparableExpectationSpecs.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Expectations.Specs;
+
+public class ComparableExpectationSpecs
+{
+    private readonly struct MyComparable(int value) : IComparable<MyComparable>
+    {
+        public readonly int Value => value;
+
+        public readonly int CompareTo(MyComparable other)
+          => value.CompareTo(other.Value);
+    }
+
+    [Fact]
+    public void Expect_To_Returns_ComparableTypeAssertions()
+    {
+        var compValue = new MyComparable(11);
+
+        // Act: We are testing Expect(...).To() itself
+        var assertions = Expect(compValue).To();
+
+        // Assert
+        Expect(assertions).To().BeOfType<ComparableTypeAssertions<MyComparable>>();
+        assertions.BeGreaterThan(new MyComparable(10));
+
+        // Verify API equivalency
+        var shouldResult = compValue.Should();
+        Expect(assertions).To().BeSameAssertionAs(shouldResult);
+    }
+}

--- a/tests/FluentAssertions.Expectations.Specs/FluentAssertions.Expectations.Specs.csproj
+++ b/tests/FluentAssertions.Expectations.Specs/FluentAssertions.Expectations.Specs.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentAssertions.Analyzers">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Adds Expect(..).To() extensions for `IComparable<T>`.