### PR TITLE
Refactor: IExpectation

### DIFF
--- a/src/FluentAssertions.Expectations/BoolExpectations.cs
+++ b/src/FluentAssertions.Expectations/BoolExpectations.cs
@@ -4,17 +4,8 @@
 using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Expectations;
-
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="bool"/> subject</summary>
-    public static Expectation<bool> Expect(bool actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="bool"/> subject</summary>
-    public static Expectation<bool?> Expect(bool? actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about Guid values</summary>
+ 
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about <see cref="bool"/> values</summary>
 [DebuggerNonUserCode]
 public static class BoolExpectationExtensions
 {
@@ -26,10 +17,10 @@ public static class BoolExpectationExtensions
      */
 
     /// <summary>Compose assertions about the <see cref="bool"/> subject</summary>
-    public static BooleanAssertions To(this Expectation<bool> expectation)
+    public static BooleanAssertions To(this IExpectation<bool> expectation)
        => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="bool"/> subject</summary>
-    public static NullableBooleanAssertions To(this Expectation<bool?> expectation)
+    public static NullableBooleanAssertions To(this IExpectation<bool?> expectation)
        => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/CollectionExpectations.cs
+++ b/src/FluentAssertions.Expectations/CollectionExpectations.cs
@@ -6,25 +6,10 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="IEnumerable{T}"/> subject</summary>
-    public static CollectionExpectation<T> Expect<T>(IEnumerable<T> actual)
-        => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="IEnumerable{T}"/> of <see cref="string"/> subject</summary>
-    public static CollectionExpectation<string> Expect(IEnumerable<string> actual)
-        => new(actual);
-}
-
-/// <summary>An <see cref="Expectation{T}"/> about a <see cref="IEnumerable{T}"/></summary>
-[DebuggerNonUserCode]
-public class CollectionExpectation<T>(IEnumerable<T> actual) : Expectation<IEnumerable<T>>(actual) { }
-
-/// <summary>Extensions to <see cref="CollectionExpectation{T}"/></summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about <see cref="IEnumerable{T}"/> values</summary>
 [DebuggerNonUserCode]
 public static class CollectionExpectationExtensions
-{    
+{
     /*
     * See Should() overloads:
     * 
@@ -33,10 +18,10 @@ public static class CollectionExpectationExtensions
     */
 
     /// <summary>Compose assertions about the <see cref="IEnumerable{T}"/> subject</summary>
-    public static StringCollectionAssertions To(this CollectionExpectation<string> expectation)
+    public static StringCollectionAssertions To(this IExpectation<IEnumerable<string>> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="IEnumerable{T}"/> of <see cref="string"/> subject</summary>
-    public static GenericCollectionAssertions<T> To<T>(this CollectionExpectation<T> expectation)
+    public static GenericCollectionAssertions<T> To<T>(this IExpectation<IEnumerable<T>> expectation)
         => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/DateTimeExpectations.cs
+++ b/src/FluentAssertions.Expectations/DateTimeExpectations.cs
@@ -4,41 +4,8 @@
 using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Expectations;
-
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="DateTime"/> subject</summary>
-    public static Expectation<DateTime> Expect(DateTime actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="DateTime"/> subject</summary>
-    public static Expectation<DateTime?> Expect(DateTime? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="DateTimeOffset"/> subject</summary>
-    public static Expectation<DateTimeOffset> Expect(DateTimeOffset actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="DateTimeOffset"/> subject</summary>
-    public static Expectation<DateTimeOffset?> Expect(DateTimeOffset? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="DateOnly"/> subject</summary>
-    public static Expectation<DateOnly> Expect(DateOnly actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="DateOnly"/> subject</summary>
-    public static Expectation<DateOnly?> Expect(DateOnly? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="TimeOnly"/> subject</summary>
-    public static Expectation<TimeOnly> Expect(TimeOnly actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="TimeOnly"/> subject</summary>
-    public static Expectation<TimeOnly?> Expect(TimeOnly? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="TimeSpan"/> subject</summary>
-    public static Expectation<TimeSpan> Expect(TimeSpan actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="TimeSpan"/> subject</summary>
-    public static Expectation<TimeSpan?> Expect(TimeSpan? actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about date and time types</summary>
+ 
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about date and time types</summary>
 [DebuggerNonUserCode]
 public static class DateTimeExpectationExtensions
 {
@@ -58,42 +25,42 @@ public static class DateTimeExpectationExtensions
     */
 
     /// <summary>Compose assertions about the <see cref="DateTime"/> subject</summary>
-    public static DateTimeAssertions To(this Expectation<DateTime> expectation)
+    public static DateTimeAssertions To(this IExpectation<DateTime> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="DateTime"/> subject</summary>
-    public static NullableDateTimeAssertions To(this Expectation<DateTime?> expectation)
+    public static NullableDateTimeAssertions To(this IExpectation<DateTime?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="DateTimeOffset"/> subject</summary>
-    public static DateTimeOffsetAssertions To(this Expectation<DateTimeOffset> expectation)
+    public static DateTimeOffsetAssertions To(this IExpectation<DateTimeOffset> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="DateTimeOffset"/> subject</summary>
-    public static NullableDateTimeOffsetAssertions To(this Expectation<DateTimeOffset?> expectation)
+    public static NullableDateTimeOffsetAssertions To(this IExpectation<DateTimeOffset?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="DateOnly"/> subject</summary>
-    public static DateOnlyAssertions To(this Expectation<DateOnly> expectation)
+    public static DateOnlyAssertions To(this IExpectation<DateOnly> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="DateOnly"/> subject</summary>
-    public static NullableDateOnlyAssertions To(this Expectation<DateOnly?> expectation)
+    public static NullableDateOnlyAssertions To(this IExpectation<DateOnly?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="TimeOnly"/> subject</summary>
-    public static TimeOnlyAssertions To(this Expectation<TimeOnly> expectation)
+    public static TimeOnlyAssertions To(this IExpectation<TimeOnly> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="TimeOnly"/> subject</summary>
-    public static NullableTimeOnlyAssertions To(this Expectation<TimeOnly?> expectation)
+    public static NullableTimeOnlyAssertions To(this IExpectation<TimeOnly?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="TimeSpan"/> subject</summary>
-    public static SimpleTimeSpanAssertions To(this Expectation<TimeSpan> expectation)
+    public static SimpleTimeSpanAssertions To(this IExpectation<TimeSpan> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="TimeSpan"/> subject</summary>
-    public static NullableSimpleTimeSpanAssertions To(this Expectation<TimeSpan?> expectation)
+    public static NullableSimpleTimeSpanAssertions To(this IExpectation<TimeSpan?> expectation)
         => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/DictionaryExpectations.cs
+++ b/src/FluentAssertions.Expectations/DictionaryExpectations.cs
@@ -6,38 +6,7 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="IDictionary{TKey, TValue}"/> subject</summary>
-    public static DictionaryExpectation<IDictionary<TKey, TValue>, TKey, TValue> Expect<TKey, TValue>(
-        IDictionary<TKey, TValue> actual
-    ) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/> subject</summary>
-    public static DictionaryExpectation<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Expect<TKey, TValue>(
-        IEnumerable<KeyValuePair<TKey, TValue>> actual
-    ) => new(actual);
-
-    /// <summary>
-    /// Create an expectation about a subject whose type <typeparamref name="TCollection"/>
-    /// implements <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>
-    /// </summary>
-    public static DictionaryExpectation<TCollection, TKey, TValue> Expect<TCollection, TKey, TValue>(
-        TCollection actual
-    ) where TCollection : IEnumerable<KeyValuePair<TKey, TValue>> => new(actual);
-}
-
-/// <summary>
-/// An <see cref="Expectation{T}"/> about a type <typeparamref name="TCollection"/> which
-/// implements <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>
-/// </summary>
-[DebuggerNonUserCode]
-public class DictionaryExpectation<TCollection, TKey, TValue>(TCollection actual)
-    : Expectation<TCollection>(actual)
-    where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
-{ }
-
-/// <summary>Extensions to <see cref="DictionaryExpectation{TCollection, TKey, TValue}"/></summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about dictionary values</summary>
 [DebuggerNonUserCode]
 public static class DictionaryExpectationExtensions
 {
@@ -51,12 +20,12 @@ public static class DictionaryExpectationExtensions
 
     /// <summary>Compose assertions about the <see cref="IDictionary{TKey, TValue}"/> subject</summary>
     public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> To<TKey, TValue>(
-       this DictionaryExpectation<IDictionary<TKey, TValue>, TKey, TValue> expectation)
+       this IExpectation<IDictionary<TKey, TValue>> expectation)
            => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/> subject</summary>
     public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> To<TKey, TValue>(
-        this DictionaryExpectation<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> expectation)
+        this IExpectation<IEnumerable<KeyValuePair<TKey, TValue>>> expectation)
             => expectation.Subject.Should();
 
     /// <summary>
@@ -64,6 +33,6 @@ public static class DictionaryExpectationExtensions
     /// implements <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>
     /// </summary>
     public static GenericDictionaryAssertions<TCollection, TKey, TValue> To<TCollection, TKey, TValue>(
-        this DictionaryExpectation<TCollection, TKey, TValue> expectation) where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        this IExpectation<TCollection> expectation) where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
             => expectation.Subject.Should<TCollection, TKey, TValue>();
 }

--- a/src/FluentAssertions.Expectations/Expectation.cs
+++ b/src/FluentAssertions.Expectations/Expectation.cs
@@ -7,18 +7,37 @@ namespace FluentAssertions.Expectations;
 /// Container for all overloads of <c>static Expect(...)</c>
 /// </summary>
 [DebuggerNonUserCode]
-public static partial class Expectation { }
+public static partial class Expectation
+{
+    public static IExpectation<T> Expect<T>(T? actual) => new ExpectationValue<T>(actual!);
+
+    [DebuggerNonUserCode]
+    private class ExpectationValue<T>(T subject) : IExpectation<T>
+    {
+        public T Subject { get; } = subject;
+
+        object? IExpectation.Subject => this.Subject;
+    }
+}
 
 /// <summary>
-/// An expectation about a given <see cref="Subject"/>
+/// An expectation about a generic <see cref="object"/> <see cref="Subject"/>
 /// </summary>
-/// <typeparam name="T"></typeparam>
-/// <param name="subject"></param>
-[DebuggerNonUserCode]
-public class Expectation<T>(T subject)
+public interface IExpectation
 {
     /// <summary>
     /// The subject of the expectation
     /// </summary>
-    public T Subject { get; } = subject;
+    object? Subject { get; }
+}
+
+/// <summary>
+/// An expectation about a given <see cref="Subject"/> of a specific type
+/// </summary>
+public interface IExpectation<out T> : IExpectation
+{
+    /// <summary>
+    /// The subject of the expectation
+    /// </summary>
+    new T Subject { get; }
 }

--- a/src/FluentAssertions.Expectations/FunctionExpectations.cs
+++ b/src/FluentAssertions.Expectations/FunctionExpectations.cs
@@ -5,27 +5,6 @@ using FluentAssertions.Specialized;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about an <see cref="Action"/></summary>
-    public static Expectation<Action> Expect(Action subject) => new(subject);
-
-    /// <summary>Create an expectation about a <c>Func&lt;<see cref="Task"/>&gt;</c></summary>
-    public static Expectation<Func<Task>> Expect(Func<Task> subject) => new(subject);
-
-    /// <summary>Create an expectation about a <c>Func&lt;<see cref="Task{T}"/>&gt;</c></summary>
-    public static Expectation<Func<Task<T>>> Expect<T>(Func<Task<T>> subject) => new(subject);
-
-    /// <summary>Create an expectation about a <see cref="Func{T}"/></summary>
-    public static Expectation<Func<T>> Expect<T>(Func<T> subject) => new(subject);
-
-    /// <summary>Create an expectation about a <see cref="TaskCompletionSource{T}"/></summary>
-    public static Expectation<TaskCompletionSource<T>> Expect<T>(TaskCompletionSource<T> subject) => new(subject);
-
-    /// <summary>Create an expectation about a <see cref="TaskCompletionSource"/></summary>
-    public static Expectation<TaskCompletionSource> Expect(TaskCompletionSource subject) => new(subject);
-}
-
 /// <summary>
 /// Extensions for function-related expectations
 /// </summary>
@@ -44,26 +23,26 @@ public static class FunctionExpectationExtensions
      */
 
     /// <summary>Compose assertions about the <see cref="Action"/> subject</summary>
-    public static ActionAssertions To(this Expectation<Action> expectation)
+    public static ActionAssertions To(this IExpectation<Action> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <c>Func&lt;<see cref="Task"/>&gt;</c> subject</summary>
-    public static NonGenericAsyncFunctionAssertions To(this Expectation<Func<Task>> expectation)
+    public static NonGenericAsyncFunctionAssertions To(this IExpectation<Func<Task>> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <c>Func&lt;<see cref="Task{T}"/>&gt;</c> subject</summary>
-    public static GenericAsyncFunctionAssertions<T> To<T>(this Expectation<Func<Task<T>>> expectation)
+    public static GenericAsyncFunctionAssertions<T> To<T>(this IExpectation<Func<Task<T>>> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="Func{T}"/> subject</summary>
-    public static FunctionAssertions<T> To<T>(this Expectation<Func<T>> expectation)
+    public static FunctionAssertions<T> To<T>(this IExpectation<Func<T>> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="TaskCompletionSource{T}"/> subject</summary>
-    public static TaskCompletionSourceAssertions<T> To<T>(this Expectation<TaskCompletionSource<T>> expectation)
+    public static TaskCompletionSourceAssertions<T> To<T>(this IExpectation<TaskCompletionSource<T>> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="TaskCompletionSource"/> subject</summary>
-    public static TaskCompletionSourceAssertions To(this Expectation<TaskCompletionSource> expectation)
+    public static TaskCompletionSourceAssertions To(this IExpectation<TaskCompletionSource> expectation)
         => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/GuidExpectations.cs
+++ b/src/FluentAssertions.Expectations/GuidExpectations.cs
@@ -5,16 +5,7 @@ using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="Guid"/> subject</summary>
-    public static Expectation<Guid> Expect(Guid actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="Guid"/> subject</summary>
-    public static Expectation<Guid?> Expect(Guid? actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about Guid values</summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about Guid values</summary>
 [DebuggerNonUserCode]
 public static class GuidExpectationExtensions
 {
@@ -26,10 +17,10 @@ public static class GuidExpectationExtensions
      */
 
     /// <summary>Compose assertions about the <see cref="Guid"/> subject</summary>
-    public static GuidAssertions To(this Expectation<Guid> expectation)
+    public static GuidAssertions To(this IExpectation<Guid> expectation)
        => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="Guid"/> subject</summary>
-    public static NullableGuidAssertions To(this Expectation<Guid?> expectation)
+    public static NullableGuidAssertions To(this IExpectation<Guid?> expectation)
        => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/IComparableExpectations.cs
+++ b/src/FluentAssertions.Expectations/IComparableExpectations.cs
@@ -5,18 +5,13 @@ using FluentAssertions.Numeric;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="IComparable{T}"/> subject</summary>
-    public static Expectation<IComparable<T>> Expect<T>(IComparable<T> actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about numeric types</summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about numeric types</summary>
 [DebuggerNonUserCode]
 public static class ComparableExpectationExtensions
 {
     /// <summary>Compose assertions about the <see cref="int"/> subject</summary>
-    public static ComparableTypeAssertions<T> To<T>(this Expectation<IComparable<T>> expectation)
+    public static ComparableTypeAssertions<T> To<T>(this IExpectation<T> expectation)
+        where T : IComparable<T>
         => expectation.Subject.Should();
 
 }

--- a/src/FluentAssertions.Expectations/IExpect.Awaiting.cs
+++ b/src/FluentAssertions.Expectations/IExpect.Awaiting.cs
@@ -19,7 +19,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that awaiting the
     /// returned task with throw an exception.
     /// </summary>
-    public static Expectation<Func<Task>> Awaiting<T>(this IExpect _, T subject, Func<T, Task> action)
+    public static IExpectation<Func<Task>> Awaiting<T>(this IExpect _, T subject, Func<T, Task> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));
@@ -31,7 +31,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that awaiting the
     /// returned task with throw an exception.
     /// </summary>
-    public static Expectation<Func<Task<TResult>>> Awaiting<T, TResult>(this IExpect _, T subject, Func<T, Task<TResult>> action)
+    public static IExpectation<Func<Task<TResult>>> Awaiting<T, TResult>(this IExpect _, T subject, Func<T, Task<TResult>> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));
@@ -43,7 +43,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that awaiting the
     /// returned task with throw an exception.
     /// </summary>
-    public static Expectation<Func<Task>> Awaiting<T>(this IExpect _, T subject, Func<T, ValueTask> action)
+    public static IExpectation<Func<Task>> Awaiting<T>(this IExpect _, T subject, Func<T, ValueTask> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));
@@ -55,7 +55,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that awaiting the
     /// returned task with throw an exception.
     /// </summary>
-    public static Expectation<Func<Task<TResult>>> Awaiting<T, TResult>(this IExpect _, T subject, Func<T, ValueTask<TResult>> action)
+    public static IExpectation<Func<Task<TResult>>> Awaiting<T, TResult>(this IExpect _, T subject, Func<T, ValueTask<TResult>> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));

--- a/src/FluentAssertions.Expectations/IExpect.Invoking.cs
+++ b/src/FluentAssertions.Expectations/IExpect.Invoking.cs
@@ -17,7 +17,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that invocation
     /// will throw an exception.
     /// </summary>
-    public static Expectation<Action> Invoking<T>(this IExpect _, T subject, Action<T> action)
+    public static IExpectation<Action> Invoking<T>(this IExpect _, T subject, Action<T> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));
@@ -29,7 +29,7 @@ public static partial class IExpectExtensions
     /// on <paramref name="subject"/>. Intended for setting up assertions that invocation
     /// will throw an exception.
     /// </summary>
-    public static Expectation<Func<TResult>> Invoking<T, TResult>(this IExpect _, T subject, Func<T, TResult> action)
+    public static IExpectation<Func<TResult>> Invoking<T, TResult>(this IExpect _, T subject, Func<T, TResult> action)
     {
         ArgumentNullException.ThrowIfNull(subject, nameof(subject));
         ArgumentNullException.ThrowIfNull(action, nameof(action));

--- a/src/FluentAssertions.Expectations/NumericExpectations.cs
+++ b/src/FluentAssertions.Expectations/NumericExpectations.cs
@@ -5,76 +5,7 @@ using FluentAssertions.Numeric;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="int"/> subject</summary>
-    public static Expectation<int> Expect(int actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="int"/> subject</summary>
-    public static Expectation<int?> Expect(int? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="uint"/> subject</summary>
-    public static Expectation<uint> Expect(uint actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="uint"/> subject</summary>
-    public static Expectation<uint?> Expect(uint? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="decimal"/> subject</summary>
-    public static Expectation<decimal> Expect(decimal actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="decimal"/> subject</summary>
-    public static Expectation<decimal?> Expect(decimal? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="byte"/> subject</summary>
-    public static Expectation<byte> Expect(byte actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="byte"/> subject</summary>
-    public static Expectation<byte?> Expect(byte? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="sbyte"/> subject</summary>
-    public static Expectation<sbyte> Expect(sbyte actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="sbyte"/> subject</summary>
-    public static Expectation<sbyte?> Expect(sbyte? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="short"/> subject</summary>
-    public static Expectation<short> Expect(short actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="short"/> subject</summary>
-    public static Expectation<short?> Expect(short? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="ushort"/> subject</summary>
-    public static Expectation<ushort> Expect(ushort actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="ushort"/> subject</summary>
-    public static Expectation<ushort?> Expect(ushort? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="long"/> subject</summary>
-    public static Expectation<long> Expect(long actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="long"/> subject</summary>
-    public static Expectation<long?> Expect(long? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="ulong"/> subject</summary>
-    public static Expectation<ulong> Expect(ulong actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="ulong"/> subject</summary>
-    public static Expectation<ulong?> Expect(ulong? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="float"/> subject</summary>
-    public static Expectation<float> Expect(float actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="float"/> subject</summary>
-    public static Expectation<float?> Expect(float? actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="double"/> subject</summary>
-    public static Expectation<double> Expect(double actual) => new(actual);
-
-    /// <summary>Create an expectation about a nullable <see cref="double"/> subject</summary>
-    public static Expectation<double?> Expect(double? actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about numeric types</summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about numeric types</summary>
 [DebuggerNonUserCode]
 public static class NumericExpectationExtensions
 {
@@ -106,90 +37,90 @@ public static class NumericExpectationExtensions
     */
 
     /// <summary>Compose assertions about the <see cref="int"/> subject</summary>
-    public static NumericAssertions<int> To(this Expectation<int> expectation)
+    public static NumericAssertions<int> To(this IExpectation<int> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="int"/> subject</summary>
-    public static NullableNumericAssertions<int> To(this Expectation<int?> expectation)
+    public static NullableNumericAssertions<int> To(this IExpectation<int?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="uint"/> subject</summary>
-    public static NumericAssertions<uint> To(this Expectation<uint> expectation)
+    public static NumericAssertions<uint> To(this IExpectation<uint> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="uint"/> subject</summary>
-    public static NullableNumericAssertions<uint> To(this Expectation<uint?> expectation)
+    public static NullableNumericAssertions<uint> To(this IExpectation<uint?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="decimal"/> subject</summary>
-    public static NumericAssertions<decimal> To(this Expectation<decimal> expectation)
+    public static NumericAssertions<decimal> To(this IExpectation<decimal> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="decimal"/> subject</summary>
-    public static NullableNumericAssertions<decimal> To(this Expectation<decimal?> expectation)
+    public static NullableNumericAssertions<decimal> To(this IExpectation<decimal?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="byte"/> subject</summary>
-    public static NumericAssertions<byte> To(this Expectation<byte> expectation)
+    public static NumericAssertions<byte> To(this IExpectation<byte> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="byte"/> subject</summary>
-    public static NullableNumericAssertions<byte> To(this Expectation<byte?> expectation)
+    public static NullableNumericAssertions<byte> To(this IExpectation<byte?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="sbyte"/> subject</summary>
-    public static NumericAssertions<sbyte> To(this Expectation<sbyte> expectation)
+    public static NumericAssertions<sbyte> To(this IExpectation<sbyte> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="sbyte"/> subject</summary>
-    public static NullableNumericAssertions<sbyte> To(this Expectation<sbyte?> expectation)
+    public static NullableNumericAssertions<sbyte> To(this IExpectation<sbyte?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="short"/> subject</summary>
-    public static NumericAssertions<short> To(this Expectation<short> expectation)
+    public static NumericAssertions<short> To(this IExpectation<short> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="short"/> subject</summary>
-    public static NullableNumericAssertions<short> To(this Expectation<short?> expectation)
+    public static NullableNumericAssertions<short> To(this IExpectation<short?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="ushort"/> subject</summary>
-    public static NumericAssertions<ushort> To(this Expectation<ushort> expectation)
+    public static NumericAssertions<ushort> To(this IExpectation<ushort> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="ushort"/> subject</summary>
-    public static NullableNumericAssertions<ushort> To(this Expectation<ushort?> expectation)
+    public static NullableNumericAssertions<ushort> To(this IExpectation<ushort?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="long"/> subject</summary>
-    public static NumericAssertions<long> To(this Expectation<long> expectation)
+    public static NumericAssertions<long> To(this IExpectation<long> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="long"/> subject</summary>
-    public static NullableNumericAssertions<long> To(this Expectation<long?> expectation)
+    public static NullableNumericAssertions<long> To(this IExpectation<long?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="ulong"/> subject</summary>
-    public static NumericAssertions<ulong> To(this Expectation<ulong> expectation)
+    public static NumericAssertions<ulong> To(this IExpectation<ulong> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="ulong"/> subject</summary>
-    public static NullableNumericAssertions<ulong> To(this Expectation<ulong?> expectation)
+    public static NullableNumericAssertions<ulong> To(this IExpectation<ulong?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="float"/> subject</summary>
-    public static NumericAssertions<float> To(this Expectation<float> expectation)
+    public static NumericAssertions<float> To(this IExpectation<float> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="float"/> subject</summary>
-    public static NullableNumericAssertions<float> To(this Expectation<float?> expectation)
+    public static NullableNumericAssertions<float> To(this IExpectation<float?> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="double"/> subject</summary>
-    public static NumericAssertions<double> To(this Expectation<double> expectation)
+    public static NumericAssertions<double> To(this IExpectation<double> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the nullable <see cref="double"/> subject</summary>
-    public static NullableNumericAssertions<double> To(this Expectation<double?> expectation)
+    public static NullableNumericAssertions<double> To(this IExpectation<double?> expectation)
         => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/ObjectExpectations.cs
+++ b/src/FluentAssertions.Expectations/ObjectExpectations.cs
@@ -1,21 +1,15 @@
 ﻿// Copyright 2024 Joshua Honig. All rights reserved.
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
- 
+
 using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a plain <see cref="object"/> subject</summary>
-    public static ObjectExpectation Expect(object? subject) => new(subject);
-}
-
-/// <summary>An <see cref="Expectation{T}"/> about a plain <see cref="object"/></summary>
-[DebuggerNonUserCode]
-public class ObjectExpectation(object? subject) : Expectation<object?>(subject) { }
-
-/// <summary>Extensions to <see cref="ObjectExpectation"/></summary>
+/// <summary>
+/// Extensions to non-generic <see cref="IExpectation"/>.
+/// Implements fallback to <see cref="ObjectAssertions"/> for types
+/// that do not have a more specific Should / To extension defined.
+/// </summary>
 [DebuggerNonUserCode]
 public static class ObjectExpectationExtensions
 {
@@ -26,6 +20,6 @@ public static class ObjectExpectationExtensions
      */
 
     /// <summary>Compose assertions about the <see cref="object"/> subject</summary>
-    public static ObjectAssertions To(this ObjectExpectation expectation)
+    public static ObjectAssertions To(this IExpectation expectation)
        => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/ReflectionExpectations.cs
+++ b/src/FluentAssertions.Expectations/ReflectionExpectations.cs
@@ -7,37 +7,10 @@ using System.Reflection;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="Assembly"/> subject</summary>
-    public static Expectation<Assembly> Expect(Assembly actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="Type"/> subject</summary>
-    public static Expectation<Type> Expect(Type actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="TypeSelector"/> subject</summary>
-    public static Expectation<TypeSelector> Expect(TypeSelector actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="ConstructorInfo"/> subject</summary>
-    public static Expectation<ConstructorInfo> Expect(ConstructorInfo actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="MethodInfo"/> subject</summary>
-    public static Expectation<MethodInfo> Expect(MethodInfo actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="MethodInfoSelector"/> subject</summary>
-    public static Expectation<MethodInfoSelector> Expect(MethodInfoSelector actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="PropertyInfo"/> subject</summary>
-    public static Expectation<PropertyInfo> Expect(PropertyInfo actual) => new(actual);
-
-    /// <summary>Create an expectation about a <see cref="PropertyInfoSelector"/> subject</summary>
-    public static Expectation<PropertyInfoSelector> Expect(PropertyInfoSelector actual) => new(actual);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about reflection-related types</summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about reflection-related types</summary>
 [DebuggerNonUserCode]
 public static class ReflectionExpectationsExtensions
-{ 
+{
     /*
      * See Should() overloads:
      * 
@@ -50,36 +23,36 @@ public static class ReflectionExpectationsExtensions
      * PropertyInfo         : https://github.com/fluentassertions/fluentassertions/blob/6.12.0/Src/FluentAssertions/AssertionExtensions.cs#L838
      * PropertyInfoSelector : https://github.com/fluentassertions/fluentassertions/blob/6.12.0/Src/FluentAssertions/AssertionExtensions.cs#L850
      */
-    
+
     /// <summary>Compose assertions about the <see cref="Assembly"/> subject</summary>
-    public static AssemblyAssertions To(this Expectation<Assembly> expectation)
+    public static AssemblyAssertions To(this IExpectation<Assembly> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="Type"/> subject</summary>
-    public static TypeAssertions To(this Expectation<Type> expectation)
+    public static TypeAssertions To(this IExpectation<Type> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="TypeSelector"/> subject</summary>
-    public static TypeSelectorAssertions To(this Expectation<TypeSelector> expectation)
+    public static TypeSelectorAssertions To(this IExpectation<TypeSelector> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="ConstructorInfo"/> subject</summary>
-    public static ConstructorInfoAssertions To(this Expectation<ConstructorInfo> expectation)
+    public static ConstructorInfoAssertions To(this IExpectation<ConstructorInfo> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="MethodInfo"/> subject</summary>
-    public static MethodInfoAssertions To(this Expectation<MethodInfo> expectation)
+    public static MethodInfoAssertions To(this IExpectation<MethodInfo> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="MethodInfoSelector"/> subject</summary>
-    public static MethodInfoSelectorAssertions To(this Expectation<MethodInfoSelector> expectation)
-        => expectation.Subject.Should();  
+    public static MethodInfoSelectorAssertions To(this IExpectation<MethodInfoSelector> expectation)
+        => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="PropertyInfo"/> subject</summary>
-    public static PropertyInfoAssertions To(this Expectation<PropertyInfo> expectation)
+    public static PropertyInfoAssertions To(this IExpectation<PropertyInfo> expectation)
         => expectation.Subject.Should();
 
     /// <summary>Compose assertions about the <see cref="PropertyInfoSelector"/> subject</summary>
-    public static PropertyInfoSelectorAssertions To(this Expectation<PropertyInfoSelector> expectation)
+    public static PropertyInfoSelectorAssertions To(this IExpectation<PropertyInfoSelector> expectation)
         => expectation.Subject.Should();
 }

--- a/src/FluentAssertions.Expectations/StringExpectations.cs
+++ b/src/FluentAssertions.Expectations/StringExpectations.cs
@@ -5,13 +5,7 @@ using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Expectations;
 
-public static partial class Expectation
-{
-    /// <summary>Create an expectation about a <see cref="string"/> subject</summary>
-    public static Expectation<string> Expect(string? actual) => new(actual!);
-}
-
-/// <summary>Extensions to <see cref="Expectation{T}"/> about a string</summary>
+/// <summary>Extensions to <see cref="IExpectation{T}"/> about a string</summary>
 [DebuggerNonUserCode]
 public static class StringExpectationExtensions
 {
@@ -22,6 +16,6 @@ public static class StringExpectationExtensions
      */
 
     /// <summary>Compose assertions about the <see cref="string"/> subject</summary>
-    public static StringAssertions To(this Expectation<string> expectation)
+    public static StringAssertions To(this IExpectation<string> expectation)
        => expectation.Subject.Should();
 }

--- a/tests/FluentAssertions.Expectations.Specs/CollectionExpectationsSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/CollectionExpectationsSpecs.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions.Collections;
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions.Collections;
 
 namespace FluentAssertions.Expectations.Specs;
 

--- a/tests/FluentAssertions.Expectations.Specs/ComparableExpectationSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/ComparableExpectationSpecs.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions.Numeric;
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions.Numeric;
 
 namespace FluentAssertions.Expectations.Specs;
 

--- a/tests/FluentAssertions.Expectations.Specs/DictionaryExpectationsSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/DictionaryExpectationsSpecs.cs
@@ -76,7 +76,7 @@ public class DictionaryExpectationsSpecs
         };
 
         // Act: We are testing Expect(...).To() itself
-        var assertions = Expect<MyKvCollection, string, int>(tCollectionValue).To();
+        var assertions = Expect(tCollectionValue).To<MyKvCollection, string, int>();
 
         // Assert
         Expect(assertions).To().BeOfType<

--- a/tests/FluentAssertions.Expectations.Specs/DictionaryExpectationsSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/DictionaryExpectationsSpecs.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions.Collections;
+﻿// Copyright 2024 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+
+using FluentAssertions.Collections;
 using System.Collections;
 
 namespace FluentAssertions.Expectations.Specs;

--- a/tests/FluentAssertions.Expectations.Specs/Documentation.ExampleSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/Documentation.ExampleSpecs.cs
@@ -4,6 +4,8 @@
 using FluentAssertions.Expectations;
 using Xunit.Sdk;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
 namespace Documentation.Example;
 
 public class ExampleSpecs
@@ -42,4 +44,3 @@ public class ExampleSpecs
         public int SomeProperty { get; set; }
     }
 }
-

--- a/tests/FluentAssertions.Expectations.Specs/ExpectationSpecs.cs
+++ b/tests/FluentAssertions.Expectations.Specs/ExpectationSpecs.cs
@@ -8,7 +8,7 @@ public class ExpectationSpecs
     [Fact]
     public void Ctor_Sets_Subject()
     {
-        var exp = new Expectation<int>(2);
+        var exp = Expectation.Expect<int>(2);
         Expect(exp.Subject).To().Be(2);
     }
 }


### PR DESCRIPTION
Refactors implementation of `Expect(..).To()` without changing the API. The two key purposes of this refactoring:

- Simplifies the implementation of `Expect(..).To()` to be a single extension method per fluid assertions type
- Makes `Expect(...).To()` fully extensible, since no additional overloads of the fixed static method `Expect(..)` are required