### PR TITLE
Docs: Add missing doc comment to Expect<T>

### DIFF
--- a/src/FluentAssertions.Expectations/Expectation.cs
+++ b/src/FluentAssertions.Expectations/Expectation.cs
@@ -9,7 +9,10 @@ namespace FluentAssertions.Expectations;
 [DebuggerNonUserCode]
 public static partial class Expectation
 {
-    public static IExpectation<T> Expect<T>(T? actual) => new ExpectationValue<T>(actual!);
+    /// <summary>
+    /// Compose assertions about <paramref name="subject"/>
+    /// </summary>
+    public static IExpectation<T> Expect<T>(T? subject) => new ExpectationValue<T>(subject!);
 
     [DebuggerNonUserCode]
     private class ExpectationValue<T>(T subject) : IExpectation<T>


### PR DESCRIPTION
Adds missing documentation comment to `Expect<T>(T? subject)`